### PR TITLE
Add misp-warninglist output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ The script generates hashes for typical false positive files. The current versio
 ## Usage
 
 ```
-    usage: fp-hashes.py [-h] [--python] [--withcomment] [--debug]
+    usage: fp-hashes.py [-h] [--python | --misp | --withcomment ]
 
     False Positive Hash Generator
 
     optional arguments:
       -h, --help     show this help message and exit
       --python       Print as Python list
+      --misp         Print as misp-warninglist
       --withcomment  Print comment lines
-      --debug        Debug output
 ```
 
 ## Output
@@ -100,4 +100,32 @@ c2a889060ed3454408bd8c4282436b5e4bc37cb6f9c2743f281b638887a406d4
 e4cbd17334f4f9494e237381446e7f6fcc2a1136
 018accf59c4975cb89aace1259ca12b4bda46f661088381db828eae2f8a8a966
 ...
+```
+
+
+misp-warninglist (--misp)
+```
+{
+  "description": "Hashes that are often included in IOC lists but are false positives.",
+  "list": [
+    "d41d8cd98f00b204e9800998ecf8427e",
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "...",
+    "7a5b9baf9a4d159445e4404177206bd5",
+    "e4cbd17334f4f9494e237381446e7f6fcc2a1136"
+    "018accf59c4975cb89aace1259ca12b4bda46f661088381db828eae2f8a8a966"
+  ],
+  "matching_attributes": [
+    "md5",
+    "sha1",
+    "sha256",
+    "filename|md5",
+    "filename|sha1",
+    "filename|sha256"
+  ],
+  "name": "Hashes that are often included in IOC lists but are false positives.",
+  "type": "string",
+  "version": 0.1
+}
 ```

--- a/fp-hashes.py
+++ b/fp-hashes.py
@@ -4,10 +4,12 @@
 # Florian Roth
 # February 2019
 # v0.1.1
+# v0.1.2 added support for misp-warninglist formatted output
 
 import hashlib
 import argparse
 import pprint
+import json
 
 FP_BYTES = [b'\x00']
 
@@ -116,12 +118,28 @@ hash_whitelist = {
          '70c65bd0e084398a87baa298c1fafa52afff402096cb350d563d309565c07e83'],
 }
 
+fp_warninglist = {
+    'description': "Hashes that are often included in IOC lists but are false positives.",
+    'name': "Hashes that are often included in IOC lists but are false positives.",
+    'type':  'string',
+    'version': 0.1,
+    'matching_attributes' : [
+       "md5",
+       "sha1",
+       "sha256",
+       "filename|md5",
+       "filename|sha1",
+       "filename|sha256"
+    ],
+    'list':[]
+}
+
 if __name__ == '__main__':
     # Parse Arguments
     parser = argparse.ArgumentParser(description='False Positive Hash Generator')
     parser.add_argument('--python', action='store_true', default=False, help='Print as Python list')
+    parser.add_argument('--misp', action='store_true', default=False, help='Print as misp-warninglist')
     parser.add_argument('--withcomment', action='store_true', default=False, help='Print comment lines')
-    parser.add_argument('--debug', action='store_true', default=False, help='Debug output')
 
     args = parser.parse_args()
 
@@ -144,6 +162,11 @@ if __name__ == '__main__':
     # Output
     if args.python:
         pprint.pprint(hash_whitelist)
+    elif args.misp:
+        for description in hash_whitelist:
+            for hash in hash_whitelist[description]:
+                fp_warninglist['list'].append(hash)
+        print(json.dumps(fp_warninglist, indent=2, sort_keys=True))
     else:
         for description in hash_whitelist:
             if args.withcomment:

--- a/fp-hashes.py
+++ b/fp-hashes.py
@@ -122,7 +122,7 @@ fp_warninglist = {
     'description': "Hashes that are often included in IOC lists but are false positives.",
     'name': "Hashes that are often included in IOC lists but are false positives.",
     'type':  'string',
-    'version': 0.1,
+    'version': 1,
     'matching_attributes' : [
        "md5",
        "sha1",


### PR DESCRIPTION
- Added an option `--misp` to print a json string formatted as a misp-warninglist
- Removed an used `--debug` option
- Updated readme to reflect the above changes

For context: https://twitter.com/cyb3rops/status/1333751011580624900

> Customer included [misp] events [..] in a scan [..] resulting in thousands of false positives [...]"
>
>IOC quality is so important. 
>Why not filter these easy FPs with a blacklist?

>Maybe [@MISP] should create an additional warning-list with your repository

